### PR TITLE
Build a Docker image for Waylon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+CHANGELOG.md
+CONTRIBUTING.md
+Procfile.development
+README.md
+waylon.gemspec
+config/waylon.yml.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.1-slim
+MAINTAINER Roger Ignazio <me@rogerignazio.com>
+
+ENV WAYLON_HOME /usr/local/waylon
+WORKDIR $WAYLON_HOME
+COPY . ${WAYLON_HOME}/
+
+RUN apt-get update
+RUN apt-get install -y build-essential libsasl2-dev memcached
+RUN bundle install --path vendor/
+
+EXPOSE 8080
+CMD curl -Lo config/waylon.yml ${WAYLON_CONFIG} && bundle exec foreman start -f Procfile.docker

--- a/Procfile.docker
+++ b/Procfile.docker
@@ -1,0 +1,2 @@
+web: bundle exec unicorn -c config/unicorn.rb
+memcache: memcached -u root -s ./tmp/memcached.sock

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ views:
 ## Deployment
 ### Docker
 The easiest way to deploy Waylon is by using the
-[rji/waylon](https://hub.docker.com/r/rogerignazio/waylon) Docker image,
-setting the `$WAYLON_CONFIG` environment variable to a URL containing a
+[rogerignazio/waylon](https://hub.docker.com/r/rogerignazio/waylon) Docker
+image, setting the `$WAYLON_CONFIG` environment variable to a URL containing a
 `waylon.yml` configuration file, like so:
 
 ```
 $ docker run    \
   -p 8080:8080  \
   -e WAYLON_CONFIG="https://gist.githubusercontent.com/rji/60fe93333247ef46542e/raw/waylon.yml" \
-  rji/waylon:v2.1.4
+  rogerignazio/waylon:v2.1.4
 ```
 
 Otherwise, if you'd like to build your own image that contains `waylon.yml` so

--- a/README.md
+++ b/README.md
@@ -97,10 +97,14 @@ ADD myconfig.yaml /usr/local/waylon/config/waylon.yml
 CMD bundle exec foreman start
 ```
 
-Then launch the container:
+### Marathon (Mesos / DCOS)
+To complement the Docker image, there is an example `marathon.json` included
+in the root of this repository. To deploy Waylon on
+[Marathon](https://mesosphere.github.io/marathon), set the value of
+`$WAYLON_CONFIG` and create a new Marathon application like so:
 
 ```
-$ docker run -p 8080:80 exampleorg/waylon
+$ curl -H 'Content-Type: application/json' -X POST -d @marathon.json http://marathon.example.com/v2/apps
 ```
 
 ### On a dedicated server

--- a/README.md
+++ b/README.md
@@ -72,7 +72,39 @@ views:
 ```
 
 ## Deployment
-The fastest way to get up and running with Waylon is to use the
+### Docker
+The easiest way to deploy Waylon is by using the
+[rji/waylon](https://hub.docker.com/r/rogerignazio/waylon) Docker image,
+setting the `$WAYLON_CONFIG` environment variable to a URL containing a
+`waylon.yml` configuration file, like so:
+
+```
+$ docker run    \
+  -p 8080:8080  \
+  -e WAYLON_CONFIG="https://gist.githubusercontent.com/rji/60fe93333247ef46542e/raw/waylon.yml" \
+  rji/waylon:v2.1.4
+```
+
+Otherwise, if you'd like to build your own image that contains `waylon.yml` so
+that you don't need to fetch it at container run time, you can base your image
+off of mine:
+
+```Dockerfile
+FROM rogerignazio/waylon:v2.1.4
+MAINTAINER You <you@example.com>
+
+ADD myconfig.yaml /usr/local/waylon/config/waylon.yml
+CMD bundle exec foreman start
+```
+
+Then launch the container:
+
+```
+$ docker run -p 8080:80 exampleorg/waylon
+```
+
+### On a dedicated server
+If you're using Puppet, you might want to check out the
 [rji/waylon](https://forge.puppetlabs.com/rji/waylon) Puppet module.
 
 For deploying the app, we have built-in support for Unicorn, a popular Ruby

--- a/marathon.json
+++ b/marathon.json
@@ -9,7 +9,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "rji/waylon:v2.1.4",
+            "image": "rogerignazio/waylon:v2.1.4",
             "network": "BRIDGE",
             "portMappings": [
                 { "containerPort": 8080, "hostPort": 0 }

--- a/marathon.json
+++ b/marathon.json
@@ -1,0 +1,30 @@
+{
+    "id": "/waylon",
+    "instances": 1,
+    "cpus": 1.0,
+    "mem": 2048.0,
+    "env": {
+        "WAYLON_CONFIG": "https://gist.githubusercontent.com/rji/60fe93333247ef46542e/raw/waylon.yml"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "rji/waylon:v2.1.4",
+            "network": "BRIDGE",
+            "portMappings": [
+                { "containerPort": 8080, "hostPort": 0 }
+            ]
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "portIndex": 0,
+            "path": "/",
+            "gracePeriodSeconds": 60,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 3
+        }
+    ]
+}


### PR DESCRIPTION
This PR introduces a Dockerfile for Waylon, as well as a published image to Docker Hub (under rogerignazio/waylon). It also includes an example `marathon.json` and updates to the README.